### PR TITLE
[FIX] website_forum: fix wrong attribute

### DIFF
--- a/addons/website_forum/views/website_forum.xml
+++ b/addons/website_forum/views/website_forum.xml
@@ -1403,7 +1403,7 @@
 
     <div t-attf-class="o_wforum_author_box d-inline-flex #{display_info and 'o_show_info'} #{compact and 'o_compact align-items-center'} #{bio_popover_data and 'o_wforum_bio_popover'}"
          t-att-data-content="bio_popover_data">
-        <t t-set="user_profile_url" value="#"/>
+        <t t-set="user_profile_url" t-valuef="#"/>
         <t t-if="object.create_uid.id == request.session.uid or object.create_uid.sudo().website_published">
             <t t-set="user_profile_url" t-value="'/forum/%s/user/%s' % (slug(forum), object.create_uid.id) + '?forum_origin=' + request.httprequest.path"/>
         </t>


### PR DESCRIPTION
After commit [1], attribute `t-value` was replaced to `value` by mistake

Steps to reproduce:
- Go to a forum post
- Click on the author image, logged in as admin
- On the profile page, unpublish the user
- As public visitor go to the previous forum post
- See the avatar image url -> `href` is now `href="#"` with this PR.

[1]: https://github.com/odoo/odoo/commit/c8c8eb3d5652e9834d0ecd5aad907ee359edb657#diff-2a4205ad15bf7b1ef0d1361b1baec87ef8a6429de19f9e0e8afce4ca16be839d

closes odoo/odoo#100586

X-original-commit: 556ff721fb7f052bee004434029659d55ea00f21
Signed-off-by: Romain Derie (rde) <rde@odoo.com>

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
