### PR TITLE
[FIX] POS: fix for quantity issue for orderline

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/ProductScreen/Orderline.js
+++ b/addons/point_of_sale/static/src/js/Screens/ProductScreen/Orderline.js
@@ -7,6 +7,7 @@ odoo.define('point_of_sale.Orderline', function(require) {
     class Orderline extends PosComponent {
         selectLine() {
             this.trigger('select-line', { orderline: this.props.line });
+            this.trigger('new-orderline-selected');
         }
         lotIconClicked() {
             this.trigger('edit-pack-lot-lines', { orderline: this.props.line });

--- a/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
@@ -16,6 +16,7 @@ odoo.define('point_of_sale.ProductScreen', function(require) {
         setup() {
             super.setup();
             useListener('update-selected-orderline', this._updateSelectedOrderline);
+            useListener('new-orderline-selected', this._newOrderlineSelected);
             useListener('set-numpad-mode', this._setNumpadMode);
             useListener('click-product', this._clickProduct);
             useListener('click-partner', this.onClickPartner);
@@ -160,6 +161,9 @@ odoo.define('point_of_sale.ProductScreen', function(require) {
             NumberBuffer.capture();
             NumberBuffer.reset();
             this.env.pos.numpadMode = mode;
+        }
+        _newOrderlineSelected(){
+            NumberBuffer.reset();
         }
         async _updateSelectedOrderline(event) {
             if (this.env.pos.numpadMode === 'quantity' && this.env.pos.disallowLineQuantityChange()) {


### PR DESCRIPTION
Impacted versions:
16.0

Steps to reproduce:
1. Start a new session in POS
2. Add two products in the order
3. Update the quantity for the first product, then update quantity for the second product

Quantity for the first product is updated correctly but for the second product the quantity is: previous digit + the new digit.

Expected behavior: Quantity should be updated correctly for each order line in the POS order.